### PR TITLE
Rectify init of RmFileHdr.num_records_per_page in RmManager

### DIFF
--- a/src/rm/rm_manager.h
+++ b/src/rm/rm_manager.h
@@ -18,8 +18,8 @@ public:
         hdr.record_size = record_size;
         hdr.num_pages = 1;
         hdr.first_free = RM_NO_PAGE;
-        // We have: sizeof(hdr) + (n + 7) / 8 + n * record_size <= PAGE_SIZE
-        hdr.num_records_per_page = (BITMAP_WIDTH * (PAGE_SIZE - 1 - (int) sizeof(RmFileHdr)) + 1) /
+        // We have: sizeof(RmPageHdr) + (n + 7) / 8 + n * record_size <= PAGE_SIZE
+        hdr.num_records_per_page = (BITMAP_WIDTH * (PAGE_SIZE - 1 - (int) sizeof(RmPageHdr)) + 1) /
                                    (1 + record_size * BITMAP_WIDTH);
         hdr.bitmap_size = (hdr.num_records_per_page + BITMAP_WIDTH - 1) / BITMAP_WIDTH;
         PfPager::write_page(fd, RM_FILE_HDR_PAGE, (uint8_t *) &hdr, sizeof(hdr));


### PR DESCRIPTION
这里计算每个页面中的记录数量的不等式：sizeof(hdr) + (n + 7) / 8 + n * record_size <= PAGE_SIZE，其中的头部大小应该是页面头部的大小而不是文件头部的大小。

In the inequality to compute the number of records in each page: sizeof(hdr) + (n + 7) / 8 + n * record_size <= PAGE_SIZE, the header size should be the size of the page header rather the file header. 

